### PR TITLE
close #20 add unknown property error to update fn.

### DIFF
--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -8,6 +8,16 @@ class ArgumentError extends Error {
   }
 }
 
+class UnknownPropertyError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'UnknownPropertyError'
+    this.message = message
+
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
 module.exports = {
   recordAlreadyExists() {
     return new ReferenceError('record already exists')
@@ -19,5 +29,9 @@ module.exports = {
 
   invalidParams(params) {
     return new ArgumentError(`expected Object, but got ${params.constructor.name} instead`)
+  },
+
+  unknownProperty(prop) {
+    return new UnknownPropertyError(`unknown property '${prop}' for record`)
   }
 }

--- a/lib/localRecord.js
+++ b/lib/localRecord.js
@@ -95,10 +95,15 @@ class LocalRecord {
     if (!recordKey) throw errors.noExistingRecord()
 
     return newProps => {
+
+      const unknownProperty = Object.keys(newProps).find(prop => {
+        return !Object.keys(record).includes(prop)
+      })
+
       // throw error if second argument is not an object
-      if (this.paramsAreNotValid(newProps)) {
-        throw errors.invalidParams(newProps)
-      }
+      if (this.paramsAreNotValid(newProps)) throw errors.invalidParams(newProps)
+      // throw error if property does not exist on object
+      if (unknownProperty) throw errors.unknownProperty(unknownProperty)
 
       Object.keys(newProps).forEach(key => record[key] = newProps[key])
 

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -33,14 +33,14 @@ describe('update', () => {
   })
 
   context('params do not match properties on object', () => {
-    it('creates additional properties for that object', () => {
+    it('throws an UnknownAttribute error', () => {
       const record = { height: 'tall' }
 
       localRecord.create(record)()
 
-      localRecord.update(record)({ eyes: 'green' })
+      const attempt = localRecord.update(record).bind(localRecord, { eyes: 'green' })
 
-      assert.deepEqual(record, { height: 'tall', eyes: 'green' })
+      assert.throws(attempt, Error, "unknown property 'eyes' for record")
     })
   })
 


### PR DESCRIPTION
When a user tries to update an object and passes a property that the object does not have:


`const existingRecord = localRecord.create({ height: 'short', eyes: 'brown' })()`

`localRecord.update(existingRecord)({ hair: 'red' })` <= throws UnknownPropertyError